### PR TITLE
Require C++17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - g++-6
+      - g++-7
 script:
   - git clone https://github.com/catchorg/Catch2.git
   - cd Catch2
@@ -16,4 +16,4 @@ script:
   - cmake --build build/
   - cd build && sudo make install
   - cd ../..
-  - CXX=/usr/bin/g++-6 && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_INSTALL_DIR=. ../ && make && make test
+  - CXX=/usr/bin/g++-7 && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_INSTALL_DIR=. ../ && make && make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,9 @@
 cmake_minimum_required(VERSION 3.9)
 project(vault VERSION 0.1.0 DESCRIPTION "Vault library for C++")
 
-set(CMAKE_CXX_STANDARD 14)
-
-if(WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHc /std:c++latest")
-else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-endif()
-
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(ENABLE_TEST "Enable tests?" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set_target_properties(vault PROPERTIES
 
 target_include_directories(vault PRIVATE include)
 target_include_directories(vault PRIVATE src)
+target_link_libraries(vault curl)
 
 if(UNIX)
 install(TARGETS vault

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -2,7 +2,7 @@
 #include "VaultClient.h"
 
 template<typename T>
-void print_response(std::experimental::optional<T> response) {
+void print_response(std::optional<T> response) {
   if (response) {
     std::cout << response.value() << std::endl;
   } else {

--- a/include/VaultClient.h
+++ b/include/VaultClient.h
@@ -3,7 +3,8 @@
 #include <unordered_map>
 #include <curl/curl.h>
 #include <functional>
-#include <experimental/optional>
+#include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -91,7 +92,7 @@ using CurlSetupCallback = std::function<void(CURL *curl)>;
 /* Aliases */
 
 using Parameters = std::unordered_map<std::string, std::string>;
-template <typename T> using optional = std::experimental::optional<T>;
+template <typename T> using optional = std::optional<T>;
 
 /* Classes */
 

--- a/src/AppRoleStrategy.cpp
+++ b/src/AppRoleStrategy.cpp
@@ -26,7 +26,7 @@ optional<AuthenticationResponse> AppRoleStrategy::authenticate(const VaultClient
 
     return AuthenticationResponse{body, token};
   } else {
-    return std::experimental::nullopt;
+    return std::nullopt;
   }
 }
 

--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -101,7 +101,7 @@ HttpClient::executeRequest(const Url& url,
       curl_easy_cleanup(curl);
       curl_slist_free_all(chunk);
 
-      return std::experimental::nullopt;
+      return std::nullopt;
     }
 
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);

--- a/src/KeyValue.cpp
+++ b/src/KeyValue.cpp
@@ -43,7 +43,7 @@ Url KeyValue::getMetadataUrl(const Path& path) {
 
 optional<std::string> KeyValue::list(const Path& path) {
   if (!client_.is_authenticated()) {
-    return std::experimental::nullopt;
+    return std::nullopt;
   }
 
   optional<HttpResponse> response;
@@ -64,12 +64,12 @@ optional<std::string> KeyValue::list(const Path& path) {
 
   return HttpClient::is_success(response)
     ? optional<std::string>(response.value().body.value())
-    : std::experimental::nullopt;
+    : std::nullopt;
 }
 
 optional<std::string> KeyValue::get(const Path& path) {
   if (!client_.is_authenticated()) {
-    return std::experimental::nullopt;
+    return std::nullopt;
   }
 
   auto response = client_.getHttpClient().get(
@@ -80,12 +80,12 @@ optional<std::string> KeyValue::get(const Path& path) {
 
   return HttpClient::is_success(response)
     ? optional<std::string>(response.value().body.value())
-    : std::experimental::nullopt;
+    : std::nullopt;
 }
 
 optional<std::string> KeyValue::put(const Path& path, Parameters parameters) {
   if (!client_.is_authenticated()) {
-    return std::experimental::nullopt;
+    return std::nullopt;
   }
 
   nlohmann::json j;
@@ -107,12 +107,12 @@ optional<std::string> KeyValue::put(const Path& path, Parameters parameters) {
 
   return response
     ? optional<std::string>(response.value().body.value())
-    : std::experimental::nullopt;
+    : std::nullopt;
 }
 
 optional<std::string> KeyValue::del(const Path& path) {
   if (!client_.is_authenticated()) {
-    return std::experimental::nullopt;
+    return std::nullopt;
   }
 
   auto response = client_.getHttpClient().del(
@@ -123,12 +123,12 @@ optional<std::string> KeyValue::del(const Path& path) {
 
   return HttpClient::is_success(response)
     ? optional<std::string>(response.value().body.value())
-    : std::experimental::nullopt;
+    : std::nullopt;
 }
 
 optional<std::string> KeyValue::del(const Path& path, std::vector<long> versions) {
   if (!client_.is_authenticated() || version_ != KeyValue::Version::v2) {
-    return std::experimental::nullopt;
+    return std::nullopt;
   }
 
   nlohmann::json j;
@@ -144,12 +144,12 @@ optional<std::string> KeyValue::del(const Path& path, std::vector<long> versions
 
   return HttpClient::is_success(response)
     ? optional<std::string>(response.value().body.value())
-    : std::experimental::nullopt;
+    : std::nullopt;
 }
 
 optional<std::string> KeyValue::destroy(const Path& path, std::vector<long> versions) {
   if (!client_.is_authenticated() || version_ != KeyValue::Version::v2) {
-    return std::experimental::nullopt;
+    return std::nullopt;
   }
 
   nlohmann::json j;
@@ -164,5 +164,5 @@ optional<std::string> KeyValue::destroy(const Path& path, std::vector<long> vers
 
   return HttpClient::is_success(response)
     ? optional<std::string>(response.value().body.value())
-    : std::experimental::nullopt;
+    : std::nullopt;
 }

--- a/src/Transit.cpp
+++ b/src/Transit.cpp
@@ -28,7 +28,7 @@ optional<std::string> Transit::decrypt(const Path& path, const Parameters& param
     auto encoded_text = nlohmann::json::parse(response.value())["data"]["plaintext"];
     return optional<std::string>(Base64::decode(encoded_text));
   } else {
-    return std::experimental::nullopt;
+    return std::nullopt;
   }
 }
 

--- a/src/Unwrap.cpp
+++ b/src/Unwrap.cpp
@@ -17,6 +17,6 @@ Unwrap::unwrap(const VaultClient& client) {
     if (HttpClient::is_success(response)) {
       return SecretId{nlohmann::json::parse(response.value().body.value())["data"]["secret_id"]};
     } else {
-      return std::experimental::nullopt;
+      return std::nullopt;
     }
 }

--- a/src/VaultHttpConsumer.cpp
+++ b/src/VaultHttpConsumer.cpp
@@ -6,7 +6,7 @@ VaultHttpConsumer::post(const VaultClient& client,
                         const Url& url,
                         Parameters parameters) {
   if (!client.is_authenticated()) {
-    return std::experimental::nullopt;
+    return std::nullopt;
   }
 
   nlohmann::json j = nlohmann::json::object();
@@ -28,5 +28,5 @@ VaultHttpConsumer::post(const VaultClient& client,
 
   return HttpClient::is_success(response)
     ? optional<std::string>(response.value().body.value())
-    : std::experimental::nullopt;
+    : std::nullopt;
 }

--- a/src/WrappedSecretAppRoleStrategy.cpp
+++ b/src/WrappedSecretAppRoleStrategy.cpp
@@ -13,5 +13,5 @@ optional<AuthenticationResponse> WrappedSecretAppRoleStrategy::authenticate(cons
 
   return secret_id
     ? AppRoleStrategy(roleId_, secret_id.value()).authenticate(vaultClient)
-    : std::experimental::nullopt;
+    : std::nullopt;
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,21 +1,21 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
-#include <experimental/optional>
+#include <optional>
 
 #include "VaultClient.h"
 
 class FailedAuth : public AuthenticationStrategy {
 public:
-  std::experimental::optional<AuthenticationResponse> authenticate(const VaultClient& client) override {
-    return std::experimental::nullopt;
+  std::optional<AuthenticationResponse> authenticate(const VaultClient& client) override {
+    return std::nullopt;
   }
 private:
 };
 
 class SuccessfulAuth : public AuthenticationStrategy {
 public:
-  std::experimental::optional<AuthenticationResponse> authenticate(const VaultClient& client) override {
-    return std::experimental::optional<AuthenticationResponse>({HttpResponseBodyString{""}, Token{"success"}});
+  std::optional<AuthenticationResponse> authenticate(const VaultClient& client) override {
+    return std::optional<AuthenticationResponse>({HttpResponseBodyString{""}, Token{"success"}});
   }
 private:
 };
@@ -66,19 +66,19 @@ TEST_CASE("VaultClient#getNamespace")
 
 TEST_CASE("HttpClient#is_success when response is empty")
 {
-  auto response = std::experimental::nullopt;
+  auto response = std::nullopt;
   REQUIRE(!HttpClient::is_success(response));
 }
 
 TEST_CASE("HttpClient#is_success when status code not 200")
 {
-  auto response = std::experimental::optional<HttpResponse>({403, HttpResponseBodyString{"Permission Denied"}});
+  auto response = std::optional<HttpResponse>({403, HttpResponseBodyString{"Permission Denied"}});
   REQUIRE(!HttpClient::is_success(response));
 }
 
 TEST_CASE("HttpClient#is_success when status 200")
 {
-  auto response = std::experimental::optional<HttpResponse>({200, HttpResponseBodyString{"OK"}});
+  auto response = std::optional<HttpResponse>({200, HttpResponseBodyString{"OK"}});
   REQUIRE(HttpClient::is_success(response));
 }
 


### PR DESCRIPTION
Howdy! I'm evaluating this library for a project I'm putting together at work, so first of all, thank you for building it.

Since it did not build on my platform (Mac OS X, using the latest toolchain shipped with XCode) I'd like to share the modifications I had to make to get it working.

From a cursory scan of your pull requests for this repo I think you might have run into some portability issues stemming from the fact that `optional` was an experimental feature until C++17. This patch makes the library use the non-experimental `std::optional` that was introduced in C++17, and it will halt the build on any compilers that only support C++14 or earlier. Theoretically, as long as that invariant holds, the library should be much more portable! If you, or someone you love, is stuck using an older compiler, might I suggest [Boost.Optional](https://www.boost.org/doc/libs/1_71_0/libs/optional/doc/html/index.html)?