### PR TITLE
marking VaultClient and HttpClient public methods as virtual

### DIFF
--- a/include/VaultClient.h
+++ b/include/VaultClient.h
@@ -107,10 +107,10 @@ public:
   explicit HttpClient(VaultConfig& config);
   HttpClient(VaultConfig& config, HttpErrorCallback errorCallback);
 
-  [[nodiscard]] std::optional<HttpResponse> get(const Url& url, const Token& token, const Namespace& ns) const;
-  [[nodiscard]] std::optional<HttpResponse> post(const Url& url, const Token& token, const Namespace& ns, std::string value) const;
-  [[nodiscard]] std::optional<HttpResponse> del(const Url& url, const Token& token, const Namespace& ns) const;
-  [[nodiscard]] std::optional<HttpResponse> list(const Url& url, const Token& token, const Namespace& ns) const;
+  [[nodiscard]] virtual std::optional<HttpResponse> get(const Url& url, const Token& token, const Namespace& ns) const;
+  [[nodiscard]] virtual std::optional<HttpResponse> post(const Url& url, const Token& token, const Namespace& ns, std::string value) const;
+  [[nodiscard]] virtual std::optional<HttpResponse> del(const Url& url, const Token& token, const Namespace& ns) const;
+  [[nodiscard]] virtual std::optional<HttpResponse> list(const Url& url, const Token& token, const Namespace& ns) const;
 
   static bool is_success(std::optional<HttpResponse> response);
 private:
@@ -182,17 +182,17 @@ public:
   VaultClient(VaultConfig& config, AuthenticationStrategy& authStrategy);
   VaultClient(VaultConfig& config, AuthenticationStrategy& authStrategy, HttpErrorCallback httpErrorCallback);
 
-  [[nodiscard]] bool is_authenticated() const { return !token_.empty(); }
-  [[nodiscard]] Url getUrl(const std::string& base, const Path& path) const;
+  [[nodiscard]] virtual bool is_authenticated() const { return !token_.empty(); }
+  [[nodiscard]] virtual Url getUrl(const std::string& base, const Path& path) const;
 
-  [[nodiscard]] bool getDebug() const { return debug_; }
-  [[nodiscard]] bool getTls() const { return tls_; }
-  [[nodiscard]] VaultHost getHost() const { return host_; }
-  [[nodiscard]] VaultPort getPort() const { return port_; }
-  [[nodiscard]] Token getToken() const { return token_; }
-  [[nodiscard]] Namespace getNamespace() const { return namespace_; }
-  [[nodiscard]] const HttpClient& getHttpClient() const { return httpClient_; }
-  [[nodiscard]] AuthenticationStrategy& getAuthenticationStrategy() const { return authStrategy_; }
+  [[nodiscard]] virtual bool getDebug() const { return debug_; }
+  [[nodiscard]] virtual bool getTls() const { return tls_; }
+  [[nodiscard]] virtual VaultHost getHost() const { return host_; }
+  [[nodiscard]] virtual VaultPort getPort() const { return port_; }
+  [[nodiscard]] virtual Token getToken() const { return token_; }
+  [[nodiscard]] virtual Namespace getNamespace() const { return namespace_; }
+  [[nodiscard]] virtual const HttpClient& getHttpClient() const { return httpClient_; }
+  [[nodiscard]] virtual AuthenticationStrategy& getAuthenticationStrategy() const { return authStrategy_; }
 
 private:
   bool debug_;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -20,6 +20,40 @@ public:
 private:
 };
 
+class MockHttpClient : public HttpClient {
+public:
+  void SetResponse(std::optional<HttpResponse> response) {
+    response_ = response;
+  }
+
+  [[nodiscard]] std::optional<HttpResponse> get(const Url& url, const Token& token, const Namespace& ns) const override {
+    return response_;
+  }
+  [[nodiscard]] std::optional<HttpResponse> post(const Url& url, const Token& token, const Namespace& ns, std::string value) const override {
+    return response_;
+  }
+  [[nodiscard]] std::optional<HttpResponse> del(const Url& url, const Token& token, const Namespace& ns) const override {
+    return response_;
+  }
+  [[nodiscard]] std::optional<HttpResponse> list(const Url& url, const Token& token, const Namespace& ns) const override {
+    return response_;
+  }
+private:
+  std::optional<HttpResponse> response_;
+};
+
+class MockVaultClient : public VaultClient {
+public:
+  MockVaultClient(VaultConfig& config, AuthenticationStrategy& authStrategy, const MockHttpClient& mockHttpClient)
+    : VaultClient(config, authStrategy), mockHttpClient_(mockHttpClient) {}
+
+  [[nodiscard]] const HttpClient& getHttpClient() const override {
+    return mockHttpClient_;
+  }
+private:
+  const MockHttpClient& mockHttpClient_;
+};
+
 auto config = VaultConfigBuilder().build();
 
 TEST_CASE("VaultClient#is_authenticated failure")


### PR DESCRIPTION
In order to create [mock](https://github.com/google/googletest/blob/master/googlemock/docs/for_dummies.md) instances of `VaultClient` and `HttpClient` (which you may want to do for testing, at some point), their methods need to be marked `virtual` so we can define `override` functions for them later.

You may want to do this for other classes at some point, but these two seem like the ideal place to start since `HttpClient` is tightly coupled to an object with real side effects (`CURL`) and is not dependency injectable into `VaultClient`.