### PR TITLE
Add a build instruction that omits the catch2 dep

### DIFF
--- a/.muse.toml
+++ b/.muse.toml
@@ -1,0 +1,1 @@
+build = "cmake -DENABLE_TEST=OFF"


### PR DESCRIPTION
The Muse system, which includes infer, can analyze libvault automatically if you'd like.  We just need to activate this organization and tell Muse either how to install without the Catch2 dependency or how to install Catch2.  This PR opts to instruct the system to build without Catch2.