### PR TITLE
Use CMAKE_CURRENT_BINARY_DIR consistently for installs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ if (INSTALL)
           DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libvault")
 
   configure_file(vault.pc.in vault.pc @ONLY)
-  install(FILES "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc"
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
           DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endif (INSTALL)
 


### PR DESCRIPTION
abedra/libvault#100
Currently CMAKE_CURRENT_BINARY_DIR is mixed with CMAKE_BINARY_DIR in the CMakeLists.txt. This creates errors when libvault is not built directly, but as part of a larger project and is referred by add_subdirectory()