### PR TITLE
Fix usage of incorrect data type in curl_easy_getinfo

### DIFF
--- a/include/VaultClient.h
+++ b/include/VaultClient.h
@@ -250,13 +250,13 @@ namespace Vault {
             }
 
             long responseCode = 0;
-            std::string url;
+            char * url = nullptr;
             curl_easy_getinfo(curl_, CURLINFO_RESPONSE_CODE, &responseCode);
             curl_easy_getinfo(curl_, CURLINFO_EFFECTIVE_URL, &url);
 
             return std::optional<Vault::HttpResponse>({
                 Vault::HttpResponseStatusCode{responseCode},
-                Vault::HttpResponseUrl{url.length() ? url : "<no response url returned>"},
+                Vault::HttpResponseUrl{(url && *url) ? url : "<no response url returned>"},
                 Vault::HttpResponseBodyString{buffer},
             });
         }


### PR DESCRIPTION
The bug that this fixes causes libvault to crash when linked against certain versions of curl