### PR TITLE
New: Add JwtAuthPointStrategy for authentication module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(
   src/auth/UserPass.cpp
   src/auth/strategies/AppRoleStrategy.cpp
   src/auth/strategies/JwtStrategy.cpp
+  src/auth/strategies/JwtAuthPointStrategy.cpp
   src/auth/strategies/LdapStrategy.cpp
   src/auth/strategies/TlsStrategy.cpp
   src/auth/strategies/WrappedSecretAppRoleStrategy.cpp

--- a/include/VaultClient.h
+++ b/include/VaultClient.h
@@ -80,6 +80,7 @@ LIBVAULT_TINY_STRING(SecretMount)
 LIBVAULT_TINY_STRING(Token)
 LIBVAULT_TINY_STRING(Url)
 LIBVAULT_TINY_STRING(Jwt)
+LIBVAULT_TINY_STRING(AuthPoint)
 
 LIBVAULT_TINY_LONG(Timeout)
 LIBVAULT_TINY_LONG(Threshold)
@@ -491,6 +492,23 @@ private:
   Vault::RoleId role_;
   Vault::Jwt jwt_;
 };
+
+class JwtAuthPointStrategy : public AuthenticationStrategy {
+public:
+  explicit JwtAuthPointStrategy(RoleId role, Jwt jwt, std::string authPoint)
+      : role_(std::move(role)), jwt_(std::move(jwt)), authPoint_(authPoint) {}
+
+  std::optional<AuthenticationResponse>
+  authenticate(const Client &client) override;
+
+private:
+  Url getUrl(const Client &client);
+
+  Vault::RoleId role_;
+  Vault::Jwt jwt_;
+  std::string authPoint_;
+};
+
 
 class Ldap {
   explicit Ldap(const Client &client) : client_(client) {}

--- a/include/VaultClient.h
+++ b/include/VaultClient.h
@@ -495,8 +495,8 @@ private:
 
 class JwtAuthPointStrategy : public AuthenticationStrategy {
 public:
-  explicit JwtAuthPointStrategy(RoleId role, Jwt jwt, std::string authPoint)
-      : role_(std::move(role)), jwt_(std::move(jwt)), authPoint_(authPoint) {}
+  explicit JwtAuthPointStrategy(RoleId role, Jwt jwt, AuthPoint authPoint)
+      : role_(std::move(role)), jwt_(std::move(jwt)), authPoint_(std::move(authPoint)) {}
 
   std::optional<AuthenticationResponse>
   authenticate(const Client &client) override;
@@ -506,7 +506,7 @@ private:
 
   Vault::RoleId role_;
   Vault::Jwt jwt_;
-  std::string authPoint_;
+  Vault::AuthPoint authPoint_;
 };
 
 

--- a/src/auth/strategies/JwtAuthPointStrategy.cpp
+++ b/src/auth/strategies/JwtAuthPointStrategy.cpp
@@ -1,0 +1,18 @@
+#include "VaultClient.h"
+#include "json.hpp"
+
+std::optional<Vault::AuthenticationResponse>
+Vault::JwtAuthPointStrategy::authenticate(const Vault::Client &client) {
+  return HttpConsumer::authenticate(client, getUrl(client), [this]() {
+    nlohmann::json j;
+    j = nlohmann::json::object();
+    j["role"] = role_.value();
+    j["jwt"] = jwt_.value();
+    return j.dump();
+  });
+}
+
+Vault::Url Vault::JwtAuthPointStrategy::getUrl(const Vault::Client &client) {
+
+  return client.getUrl("/v1/auth/" + authPoint_ +  "/login", Path{});
+}

--- a/src/auth/strategies/JwtAuthPointStrategy.cpp
+++ b/src/auth/strategies/JwtAuthPointStrategy.cpp
@@ -14,5 +14,5 @@ Vault::JwtAuthPointStrategy::authenticate(const Vault::Client &client) {
 
 Vault::Url Vault::JwtAuthPointStrategy::getUrl(const Vault::Client &client) {
 
-  return client.getUrl("/v1/auth/" + authPoint_ +  "/login", Path{});
+  return client.getUrl("/v1/auth/" + authPoint_.value() +  "/login", Path{});
 }


### PR DESCRIPTION
Hello, 

I am looking to add some functionality to allow a user to configure the jwt endpoint. This is what I came up with and got working with my local vault instance. Is this something we can get added to the main repo? If not, is there a better way to do this? 

awesome library! Thanks for putting this together. 