### PR TITLE
clear build warning list

### DIFF
--- a/include/VaultClient.h
+++ b/include/VaultClient.h
@@ -328,7 +328,7 @@ public:
       Config &config, AuthenticationStrategy &authStrategy, // NOLINT
       HttpErrorCallback httpErrorCallback,
       ResponseErrorCallback responseErrorCallback =
-          [](const HttpResponse &err) {});
+          []([[maybe_unused]] const HttpResponse &err) {});
   virtual ~Client() = default;
 
   [[nodiscard]] virtual bool is_authenticated() const {
@@ -408,7 +408,7 @@ public:
   explicit TokenStrategy(Token token) : token_(std::move(token)) {}
 
   std::optional<AuthenticationResponse>
-  authenticate(const Client &vaultClient) override {
+  authenticate([[maybe_unused]] const Client &vaultClient) override {
     return AuthenticationResponse{HttpResponseBodyString{""}, token_};
   }
 

--- a/src/domain/VaultClient.cpp
+++ b/src/domain/VaultClient.cpp
@@ -3,10 +3,14 @@
 
 Vault::Client::Client(Vault::Config &config,
                       AuthenticationStrategy &authStrategy)
-    : host_(config.getHost()), port_(config.getPort()),
-      namespace_(config.getNamespace()), tls_(config.getTls()),
-      authStrategy_(authStrategy), httpClient_(HttpClient(config)),
-      debug_(config.getDebug()), caBundle_(config.getCaBundle()) {
+    : debug_(config.getDebug())
+    , tls_(config.getTls())
+    , host_(config.getHost())
+    , port_(config.getPort())
+    , namespace_(config.getNamespace())
+    , httpClient_(HttpClient(config))
+    , authStrategy_(authStrategy)
+    , caBundle_(config.getCaBundle()) {
   if (auto result = authStrategy_.authenticate(*this)) {
     token_ = result.value().token;
   }
@@ -16,23 +20,30 @@ Vault::Client::Client(Vault::Config &config,
                       AuthenticationStrategy &authStrategy,
                       HttpErrorCallback httpErrorCallback,
                       ResponseErrorCallback responseErrorCallback)
-    : host_(config.getHost()), port_(config.getPort()),
-      namespace_(config.getNamespace()), tls_(config.getTls()),
-      authStrategy_(authStrategy),
-      httpClient_(HttpClient(config, std::move(httpErrorCallback),
-                             std::move(responseErrorCallback))),
-      debug_(config.getDebug()), caBundle_(config.getCaBundle()) {
+    : debug_(config.getDebug())
+    , tls_(config.getTls())
+    , host_(config.getHost())
+    , port_(config.getPort())
+    , namespace_(config.getNamespace())
+    , httpClient_(HttpClient(config, std::move(httpErrorCallback),
+                             std::move(responseErrorCallback)))
+    , authStrategy_(authStrategy)
+    , caBundle_(config.getCaBundle()) {
   if (auto result = authStrategy_.authenticate(*this)) {
     token_ = result.value().token;
   }
 }
 
 Vault::Client::Client(const Vault::Client &other, Vault::Token token)
-    : host_(other.getHost()), port_(other.getPort()),
-      namespace_(other.getNamespace()), tls_(other.getTls()),
-      authStrategy_(other.getAuthenticationStrategy()),
-      httpClient_(other.getHttpClient()), debug_(other.getDebug()),
-      token_(std::move(token)), caBundle_(other.getCaBundle()) {}
+    : debug_(other.getDebug())
+    , tls_(other.getTls())
+    , host_(other.getHost())
+    , port_(other.getPort())
+    , token_(std::move(token))
+    , namespace_(other.getNamespace())
+    , httpClient_(other.getHttpClient())
+    , authStrategy_(other.getAuthenticationStrategy())
+    , caBundle_(other.getCaBundle()) {}
 
 Vault::Url Vault::Client::getUrl(const std::string &base,
                                  const Vault::Path &path) const {

--- a/src/engines/KeyValue.cpp
+++ b/src/engines/KeyValue.cpp
@@ -5,19 +5,26 @@
 #include <utility>
 
 Vault::KeyValue::KeyValue(const Vault::Client &client)
-    : version_(KeyValue::Version::v2), client_(client), mount_("secret") {}
+    : client_(client)
+    , version_(KeyValue::Version::v2)
+    , mount_("secret") {}
 
 Vault::KeyValue::KeyValue(const Vault::Client &client, Vault::SecretMount mount)
-    : version_(KeyValue::Version::v2), client_(client),
-      mount_(std::move(mount)) {}
+    : client_(client)
+    , version_(KeyValue::Version::v2)
+    , mount_(std::move(mount)) {}
 
 Vault::KeyValue::KeyValue(const Vault::Client &client,
                           KeyValue::Version version)
-    : version_(version), client_(client), mount_("secret") {}
+    : client_(client)
+    , version_(version)
+    , mount_("secret") {}
 
 Vault::KeyValue::KeyValue(const Vault::Client &client, Vault::SecretMount mount,
                           KeyValue::Version version)
-    : version_(version), client_(client), mount_(std::move(mount)) {}
+    : client_(client)
+    , version_(version)
+    , mount_(std::move(mount)) {}
 
 Vault::Url Vault::KeyValue::getUrl(const Vault::Path &path) {
   return version_ == KeyValue::Version::v1
@@ -81,7 +88,7 @@ std::optional<std::string> Vault::KeyValue::del(const Vault::Path &path,
 
   return Vault::HttpConsumer::post(
       client_, client_.getUrl("/v1" + mount_ + "/delete/", path), Parameters{},
-      [&](const Parameters &params) {
+      [&]([[maybe_unused]] const Parameters &params) {
         nlohmann::json j;
         j["versions"] = versions;
         return j.dump();
@@ -97,7 +104,7 @@ Vault::KeyValue::destroy(const Vault::Path &path,
 
   return Vault::HttpConsumer::post(
       client_, client_.getUrl("/v1" + mount_ + "/destroy/", path), Parameters{},
-      [&](const Parameters &params) {
+      [&]([[maybe_unused]] const Parameters &params) {
         nlohmann::json j;
         j["versions"] = versions;
         return j.dump();
@@ -112,7 +119,7 @@ Vault::KeyValue::undelete(const Path &path, std::vector<int64_t> versions) {
 
   return Vault::HttpConsumer::post(
       client_, client_.getUrl("/v1" + mount_ + "/undelete/", path),
-      Parameters{}, [&](const Parameters &params) {
+      Parameters{}, [&]([[maybe_unused]] const Parameters &params) {
         nlohmann::json j;
         j["versions"] = versions;
         return j.dump();

--- a/src/support/HttpClient.cpp
+++ b/src/support/HttpClient.cpp
@@ -3,8 +3,8 @@
 
 Vault::HttpClient::HttpClient(Vault::Config config)
     : config_(std::move(config)),
-      errorCallback_([&](const std::string &err) {}),
-      responseErrorCallback_([&](const HttpResponse &err) {}) {}
+      errorCallback_([&]([[maybe_unused]] const std::string &err) {}),
+      responseErrorCallback_([&]([[maybe_unused]] const HttpResponse &err) {}) {}
 
 Vault::HttpClient::HttpClient(Vault::Config config,
                               HttpErrorCallback errorCallback,
@@ -21,7 +21,7 @@ std::optional<Vault::HttpResponse>
 Vault::HttpClient::get(const Vault::Url &url, const Vault::Token &token,
                        const Vault::Namespace &ns) const {
   return executeRequest(
-      url, token, ns, [&](CURL *curl) {},
+      url, token, ns, [&]([[maybe_unused]] CURL *curl) {},
       [&](curl_slist *chunk) { return chunk; }, errorCallback_);
 }
 


### PR DESCRIPTION
remove warnings like:
* src/engines/KeyValue.cpp: warning: unused parameter 'params' [-Wunused-parameter]
* src/engines/KeyValue.cpp: warning: field 'version_' will be initialized after field 'client_' [-Wreorder-ctor]