### PR TITLE
Add List Revoked Certificate

### DIFF
--- a/include/VaultClient.h
+++ b/include/VaultClient.h
@@ -1251,6 +1251,8 @@ public:
   std::optional<std::string> tidy(const Parameters &parameters) const;
   [[nodiscard]] std::optional<std::string>
   revokeCertificate(const Parameters &parameters) const;
+  [[nodiscard]] std::optional<std::string>
+  listRevokedCertificate();
 
 private:
   [[nodiscard]] Url getUrl(const Path &path) const;

--- a/src/engines/Pki.cpp
+++ b/src/engines/Pki.cpp
@@ -138,6 +138,11 @@ Vault::Pki::revokeCertificate(const Parameters &parameters) const {
   return HttpConsumer::post(client_, getUrl(Path{"revoke"}), parameters);
 }
 
+std::optional<std::string>
+Vault::Pki::listRevokedCertificate() const {
+  return HttpConsumre::list(client_, getUrl(Path{"certs/revoked"}));
+}
+
 Vault::Url Vault::Pki::getUrl(const Path &path) const {
   return client_.getUrl("/v1/" + secretMount_,
                         path.empty() ? path : Path{"/" + path});


### PR DESCRIPTION
Hello, I noticed that the PKI is missing the listRevokedCertificates interface, with the path http://127.0.0.1:8200/v1/pki/certs/revoked. However, I need to use this interface. I'm not sure if the changes are accurate. Please review them when you have time. Thanks!