### PR TITLE
Delete unused link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ venv
 *.gch
 example/**/example
 .cache
+compile_commands.json

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,1 +1,0 @@
-cmake-build-debug/compile_commands.json


### PR DESCRIPTION
Delete unused link _compile_commands.json_. According to the CMake documentation, this file is created if the _CMAKE_EXPORT_COMPILE_COMMAND_ variable is set. In addition, this link points to a non-existent file.